### PR TITLE
Deprecate help.exercism.io

### DIFF
--- a/SETUP.org
+++ b/SETUP.org
@@ -1,5 +1,5 @@
 #+TITLE: xelisp setup
 #+AUTHOR: Jason Lewis
 
-Check out [[http://help.exercism.io/getting-started-with-emacs-lisp.html][Exercism Help]] for instructions getting started with Emacs and
+Check out [[http://exercism.io/languages/elisp][Exercism Help]] for instructions getting started with Emacs and
 Emacs Lisp.


### PR DESCRIPTION
Remove the reference to the deprecated [help.exercism.io](http://help.exercism.io) and point to [exercism.io/languages](http://exercism.io/languages/elisp) instead.

Fixes #32.