### PR TITLE
Use equal-assoc helper to not depend on order

### DIFF
--- a/exercises/word-count/word-count-test.el
+++ b/exercises/word-count/word-count-test.el
@@ -13,51 +13,51 @@
 
 
 (ert-deftest no-words-test ()
-  (should (equal (word-count "")
-                 nil)))
+  (should (equal-assoc (word-count "")
+                       nil)))
 
 
 (ert-deftest count-one-word-test ()
-  (should (equal (word-count "word")
-                 '(("word" . 1)))))
+  (should (equal-assoc (word-count "word")
+                       '(("word" . 1)))))
 
 
 (ert-deftest count-one-of-each-word-test ()
-  (should (equal (word-count "one of each")
-                 '(("each" . 1) 
-                   ("of" . 1)
-                   ("one" . 1)))))
+  (should (equal-assoc (word-count "one of each")
+                       '(("each" . 1)
+                         ("of" . 1)
+                         ("one" . 1)))))
 
 
 (ert-deftest multiple-occurrences-of-a-word-test ()
-  (should (equal (word-count "one fish two fish red fish blue fish")
-                 '(("blue" . 1) 
-                   ("red" . 1) 
-                   ("two" . 1) 
-                   ("fish" . 4)
-                   ("one" . 1)))))
+  (should (equal-assoc (word-count "one fish two fish red fish blue fish")
+                       '(("blue" . 1)
+                         ("red" . 1)
+                         ("two" . 1)
+                         ("fish" . 4)
+                         ("one" . 1)))))
 
 
 (ert-deftest ignore-punctuation-test ()
-  (should (equal (word-count "car : carpet as java : javascript!!&@$%^&")
-                 '(("javascript" . 1)
-                   ("java" . 1)
-                   ("as" . 1)
-                   ("carpet" . 1)
-                   ("car" . 1)))))
+  (should (equal-assoc (word-count "car : carpet as java : javascript!!&@$%^&")
+                       '(("javascript" . 1)
+                         ("java" . 1)
+                         ("as" . 1)
+                         ("carpet" . 1)
+                         ("car" . 1)))))
 
 
 (ert-deftest include-numbers-test ()
-  (should (equal (word-count "testing, 1, 2 testing")
-                 '(("2" . 1)
-                   ("1" . 1)
-                   ("testing" . 2)))))
+  (should (equal-assoc (word-count "testing, 1, 2 testing")
+                       '(("2" . 1)
+                         ("1" . 1)
+                         ("testing" . 2)))))
 
 
 (ert-deftest normalize-case-test ()
-  (should (equal (word-count "go Go GO Stop stop")
-                 '(("stop" . 2)
-                   ("go" . 3)))))
+  (should (equal-assoc (word-count "go Go GO Stop stop")
+                       '(("stop" . 2)
+                         ("go" . 3)))))
 
 
 (provide 'word-count)


### PR DESCRIPTION
The test code defines an `equal-assoc` helper, but didn't make use of it.  Without it the tests can only succeed if the alist has been constructed in reverse order.