### PR TITLE
Use = for comparing numbers

### DIFF
--- a/exercises/grains/grains-test.el
+++ b/exercises/grains/grains-test.el
@@ -7,32 +7,32 @@
 (load-file "grains.el")
 
 (ert-deftest square-1 ()
-  (should (equal 1 (square 1))))
+  (should (= 1 (square 1))))
 
 (ert-deftest square-2 ()
-  (should (equal 2 (square 2))))
+  (should (= 2 (square 2))))
 
 (ert-deftest square-3 ()
-  (should (equal 4 (square 3))))
+  (should (= 4 (square 3))))
 
 (ert-deftest square-4 ()
-  (should (equal 8 (square 4))))
+  (should (= 8 (square 4))))
 
 (ert-deftest square-16 ()
-  (should (equal 32768
-                 (square 16))))
+  (should (= 32768
+             (square 16))))
 
 (ert-deftest square-32 ()
-  (should (equal 2147483648
-                 (square 32))))
+  (should (= 2147483648
+             (square 32))))
 
 (ert-deftest square-64 ()
-  (should (equal 9223372036854775808
-                 (square 64))))
+  (should (= 9223372036854775808
+             (square 64))))
 
 (ert-deftest total-grains ()
-  (should (equal 18446744073709551615
-                 (total))))
+  (should (= 18446744073709551615
+             (total))))
 
 (provide 'grains-test.el)
 ;;; grains-test.el ends here.


### PR DESCRIPTION
The test is currently using `equal` which is less than ideal for numbers as it forbids differing types (such as integers and floats).  The thing is that elisp doesn't support bignums in the first place, so anything bigger than `max-positive-fixnum` overflows in a float.  A user anticipating this and using floats for everything will therefore run into the problem that this makes more than half of the tests fail as they use integers.